### PR TITLE
Fix a bug of lib.getProblemNumber()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 To be released.
 
+## 0.2.3
+
+To be released.
+
+- Fix a bug where `lib.getProblemNumber()` doesn't work as well because of platform.
+
+## 0.2.2
+
+Released on 2019-12-11
+
+- Fix a bug where the extension activation failed.
+
 ## 0.2.0
 
 Released on 2019-12-07

--- a/README.md
+++ b/README.md
@@ -16,8 +16,12 @@
 
 ### 문제 정보 보기
 
-Command Palette: `BOJ: Show Problem Information`
+Command Palette: `BOJ: Show Problem Information`  
 Key Binding: `ctrl+alt+i`
+
+파일명이 **문제번호.c** 혹은 **문제번호-추가적인설명.c** 같은 형식으로 되어있는 경우에만 문제 번호를 인식할 수 있습니다! 추가적인 설명 부분은 실제로 형식이 정해져 있지는 않습니다.
+
+(e.g. `1000.c`, `1000-a+b.c`)
 
 ![Show problem information](https://user-images.githubusercontent.com/26626194/70360470-fcf6aa00-18c1-11ea-86c3-af1d016aeef5.png)
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "Other"
   ],
   "activationEvents": [
-    "workspaceContains:/.boj"
+    "workspaceContains:.boj"
   ],
   "preview": true,
   "main": "./out/extension.js",

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -2,6 +2,7 @@ import { window, TextEditor, workspace, extensions } from "vscode";
 
 import * as vscode from "vscode";
 import * as data from "../resources/languages.json";
+import * as path from "path";
 
 export interface LanguageInfo {
   name: string;
@@ -38,9 +39,9 @@ export function getSource(): string {
 }
 
 export function getProblemNumber(): number {
-  const edtior = <TextEditor>window.activeTextEditor;
-  const filePath = edtior.document.fileName;
-  const fileName = filePath.split("/").slice(-1)[0];
+  const editor = <TextEditor>window.activeTextEditor;
+  const filePath = editor.document.fileName;
+  const fileName = path.parse(filePath).name;
 
   if (hasProblemNumberAndOthers(fileName)) {
     return Number(fileName.split("-")[0]);


### PR DESCRIPTION
There was a bug that `lib.getProblemNumber()` failed on windows because it used `/` as path separator.
So, I made the function to use `path.parse()` to guarantee multi-platform.